### PR TITLE
Cache adjustments - since we page, do not cache

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -272,9 +272,10 @@ def list_program(id, page):
             })
 
         if page > 1:
-            return plugin.finish(items, update_listing=True)
+            return plugin.finish(items, update_listing=True, cache_to_disc=False)
 
-        return items
+        xbmc.executebuiltin('SetFocus(1)')
+        return plugin.finish(items, update_listing=True, cache_to_disc=False)
 
 
 @plugin.route('/category/<id>')


### PR DESCRIPTION
Remove caching since we are paging.
Fixes issue with programs that occurs often - e.g. news (Ekot). Cache is not refreshed often enough.